### PR TITLE
Add list of hosts reading

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -512,6 +512,7 @@ catch (...)
 
 void Client::connect()
 {
+    config().setString("host", hosts[0]);
     connection_parameters = ConnectionParameters(config());
 
     if (is_interactive)
@@ -998,7 +999,7 @@ void Client::addAndCheckOptions(OptionsDescription & options_description, po::va
     /// Main commandline options related to client functionality and all parameters from Settings.
     options_description.main_description->add_options()
         ("config,c", po::value<std::string>(), "config-file path (another shorthand)")
-        ("host,h", po::value<std::string>()->default_value("localhost"), "server host")
+        ("host,h", po::value<std::vector<std::string>>()->multitoken()->default_value({"localhost"}, "localhost"), "list of server hosts")
         ("port", po::value<int>()->default_value(9000), "server port")
         ("secure,s", "Use TLS connection")
         ("user,u", po::value<std::string>()->default_value("default"), "user")
@@ -1120,7 +1121,7 @@ void Client::processOptions(const OptionsDescription & options_description,
     if (options.count("config"))
         config().setString("config-file", options["config"].as<std::string>());
     if (options.count("host") && !options["host"].defaulted())
-        config().setString("host", options["host"].as<std::string>());
+        hosts = options["host"].as<std::vector<std::string>>();
     if (options.count("interleave-queries-file"))
         interleave_queries_files = options["interleave-queries-file"].as<std::vector<std::string>>();
     if (options.count("pager"))

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -29,6 +29,7 @@ protected:
                         const std::vector<Arguments> & external_tables_arguments) override;
     void processConfig() override;
 
+    std::vector<String> hosts{};
 private:
     void printChangedSettings() const;
     std::vector<String> loadWarningMessages();

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1580,7 +1580,7 @@ void ClientBase::init(int argc, char ** argv)
 
     /// Output of help message.
     if (options.count("help")
-        || (options.count("host") && options["host"].as<std::string>() == "elp")) /// If user writes -help instead of --help.
+        || (options.count("host") && options["host"].as<std::vector<std::string>>()[0] == "elp")) /// If user writes -help instead of --help.
     {
         printHelpMessage(options_description);
         exit(0);


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The param `--host` can receive some hosts. In the future client will use it to choose host for connection. Choise will be depend on availability and workload of hosts. 


Detailed description / Documentation draft:
...


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
