### PR TITLE
Client fault tolerant connection

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -512,6 +512,7 @@ catch (...)
 
 void Client::connect()
 {
+    config().setString("host", hosts[0]);
     connection_parameters = ConnectionParameters(config());
 
     if (is_interactive)
@@ -998,7 +999,7 @@ void Client::addAndCheckOptions(OptionsDescription & options_description, po::va
     /// Main commandline options related to client functionality and all parameters from Settings.
     options_description.main_description->add_options()
         ("config,c", po::value<std::string>(), "config-file path (another shorthand)")
-        ("host,h", po::value<std::string>()->default_value("localhost"), "server host")
+        ("host,h", po::value<std::vector<std::string>>()->multitoken()->default_value({"localhost"}, "localhost"), "list of server hosts")
         ("port", po::value<int>()->default_value(9000), "server port")
         ("secure,s", "Use TLS connection")
         ("user,u", po::value<std::string>()->default_value("default"), "user")
@@ -1120,7 +1121,7 @@ void Client::processOptions(const OptionsDescription & options_description,
     if (options.count("config"))
         config().setString("config-file", options["config"].as<std::string>());
     if (options.count("host") && !options["host"].defaulted())
-        config().setString("host", options["host"].as<std::string>());
+        hosts = options["host"].as<std::vector<std::string>>();
     if (options.count("interleave-queries-file"))
         interleave_queries_files = options["interleave-queries-file"].as<std::vector<std::string>>();
     if (options.count("pager"))

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -512,49 +512,78 @@ catch (...)
 
 void Client::connect()
 {
+    /// TODO added for testing purposes, remove once specifying multiple addresses is supported
+    bool is_secure = config().getBool("secure", false);
+    ports = {
+        config().getInt("port", config().getInt(is_secure ? "tcp_port_secure" : "tcp_port", is_secure ? DBMS_DEFAULT_SECURE_PORT : DBMS_DEFAULT_PORT)),
+        10000,
+        11000
+    };
     config().setString("host", hosts[0]);
-    connection_parameters = ConnectionParameters(config());
 
-    if (is_interactive)
-        std::cout << "Connecting to "
-                    << (!connection_parameters.default_database.empty() ? "database " + connection_parameters.default_database + " at "
-                                                                        : "")
-                    << connection_parameters.host << ":" << connection_parameters.port
-                    << (!connection_parameters.user.empty() ? " as user " + connection_parameters.user : "") << "." << std::endl;
+    connection_parameters = ConnectionParameters(config());
 
     String server_name;
     UInt64 server_version_major = 0;
     UInt64 server_version_minor = 0;
     UInt64 server_version_patch = 0;
 
-    try
+    for (size_t attempted_address_index = 0; attempted_address_index < hosts.size(); ++attempted_address_index)
     {
-        connection = Connection::createConnection(connection_parameters, global_context);
+        connection_parameters.host = hosts[attempted_address_index];
+        connection_parameters.port = ports[attempted_address_index];
 
-        if (max_client_network_bandwidth)
+        if (is_interactive)
+            std::cout << "Connecting to "
+                      << (!connection_parameters.default_database.empty() ? "database " + connection_parameters.default_database + " at "
+                                                                          : "")
+                      << connection_parameters.host << ":" << connection_parameters.port
+                      << (!connection_parameters.user.empty() ? " as user " + connection_parameters.user : "") << "." << std::endl;
+
+        try
         {
-            ThrottlerPtr throttler = std::make_shared<Throttler>(max_client_network_bandwidth, 0, "");
-            connection->setThrottler(throttler);
-        }
+            connection = Connection::createConnection(connection_parameters, global_context);
 
-        connection->getServerVersion(
-            connection_parameters.timeouts, server_name, server_version_major, server_version_minor, server_version_patch, server_revision);
-    }
-    catch (const Exception & e)
-    {
-        /// It is typical when users install ClickHouse, type some password and instantly forget it.
-        if ((connection_parameters.user.empty() || connection_parameters.user == "default")
-            && e.code() == DB::ErrorCodes::AUTHENTICATION_FAILED)
+            if (max_client_network_bandwidth)
+            {
+                ThrottlerPtr throttler = std::make_shared<Throttler>(max_client_network_bandwidth, 0, "");
+                connection->setThrottler(throttler);
+            }
+
+            connection->getServerVersion(
+                connection_parameters.timeouts, server_name, server_version_major, server_version_minor, server_version_patch, server_revision);
+            break;
+        }
+        catch (const Exception & e)
         {
-            std::cerr << std::endl
-                << "If you have installed ClickHouse and forgot password you can reset it in the configuration file." << std::endl
-                << "The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml" << std::endl
-                << "and deleting this file will reset the password." << std::endl
-                << "See also /etc/clickhouse-server/users.xml on the server where ClickHouse is installed." << std::endl
-                << std::endl;
-        }
+            /// It is typical when users install ClickHouse, type some password and instantly forget it.
+            /// This problem can't be fixed with reconnection so it is not attempted
+            if ((connection_parameters.user.empty() || connection_parameters.user == "default")
+                && e.code() == DB::ErrorCodes::AUTHENTICATION_FAILED)
+            {
+                std::cerr << std::endl
+                          << "If you have installed ClickHouse and forgot password you can reset it in the configuration file." << std::endl
+                          << "The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml" << std::endl
+                          << "and deleting this file will reset the password." << std::endl
+                          << "See also /etc/clickhouse-server/users.xml on the server where ClickHouse is installed." << std::endl
+                          << std::endl;
+                throw;
+            }
+            else
+            {
+                if (attempted_address_index == hosts.size() - 1)
+                    throw;
 
-        throw;
+                std::cerr << "Connection attempt to database at "
+                          << connection_parameters.host << ":" << connection_parameters.port
+                          << " resulted in failure"
+                          << std::endl
+                          << getExceptionMessage(e, false)
+                          << std::endl
+                          << "Attempting connection to the next provided address"
+                          << std::endl;
+            }
+        }
     }
 
     server_version = toString(server_version_major) + "." + toString(server_version_minor) + "." + toString(server_version_patch);

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -29,6 +29,7 @@ protected:
                         const std::vector<Arguments> & external_tables_arguments) override;
     void processConfig() override;
 
+    std::vector<String> hosts{};
 private:
     void printChangedSettings() const;
     std::vector<String> loadWarningMessages();

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -30,6 +30,7 @@ protected:
     void processConfig() override;
 
     std::vector<String> hosts{};
+    std::vector<int> ports{};
 private:
     void printChangedSettings() const;
     std::vector<String> loadWarningMessages();

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1580,7 +1580,7 @@ void ClientBase::init(int argc, char ** argv)
 
     /// Output of help message.
     if (options.count("help")
-        || (options.count("host") && options["host"].as<std::string>() == "elp")) /// If user writes -help instead of --help.
+        || (options.count("host") && options["host"].as<std::vector<std::string>>()[0] == "elp")) /// If user writes -help instead of --help.
     {
         printHelpMessage(options_description);
         exit(0);


### PR DESCRIPTION
Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Parameter `host` can accept multiple hosts. In case of unavailability of one of them, the client will try to connect to another.


Detailed description / Documentation draft:
Client attempts reconnection only on the initial connection before any queries are executed.
Client does not attempt reconnection in case of authentication error (wrong password/login).


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
